### PR TITLE
Fixed a bug in default keymap

### DIFF
--- a/keyboard/ergodox/keymap.c
+++ b/keyboard/ergodox/keymap.c
@@ -162,7 +162,7 @@ static const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                                            TRNS,
                                  TRNS,TRNS,TRNS,
         // right hand
-             SLCK,NLCK,PSLS,PAST,PAST,PMNS,BSPC,
+             TRNS,NLCK,PSLS,PAST,PAST,PMNS,BSPC,
              TRNS,NO,  P7,  P8,  P9,  PMNS,BSPC,
                   NO,  P4,  P5,  P6,  PPLS,PENT,
              TRNS,NO,  P1,  P2,  P3,  PPLS,PENT,
@@ -185,9 +185,9 @@ enum function_id {
 static const uint16_t PROGMEM fn_actions[] = {
     ACTION_FUNCTION(TEENSY_KEY),                    // FN0 - Teensy key
     ACTION_LAYER_MOMENTARY(1),                      // FN1 - switch to Layer1
-    ACTION_LAYER_SET(2, ON_PRESS),                  // FN2 - push Layer2
-    ACTION_LAYER_SET(3, ON_PRESS),                  // FN3 - push Layer3
-    ACTION_LAYER_SET(0, ON_PRESS),                  // FN4 - push Layer0
+    ACTION_LAYER_SET(2, ON_PRESS),                  // FN2 - set Layer2
+    ACTION_LAYER_TOGGLE(3),                         // FN3 - toggle Layer3 aka Numpad layer
+    ACTION_LAYER_SET(0, ON_PRESS),                  // FN4 - set Layer0
 };
 
 void action_function(keyrecord_t *event, uint8_t id, uint8_t opt)


### PR DESCRIPTION
There was no way to leave the numpad layer because there was ScrlLck assigned to that key.
