### PR TITLE
Updated ErgoDox build section. Added barebones template.

### DIFF
--- a/keyboard/ergodox/Ergodox-FAQ.md
+++ b/keyboard/ergodox/Ergodox-FAQ.md
@@ -41,17 +41,33 @@ https://github.com/cub-uanic/tmk_keyboard/tree/master
     make -f Makefile.lufa clean
 
     # use one of these
-    make -f Makefile.lufa
-    make -f Makefile.lufa dvorak
-    make -f Makefile.lufa colemak
-    make -f Makefile.lufa workman
-    make -f Makefile.lufa micro
-    make -f Makefile.lufa cub
+    make -f Makefile.lufa #defaults to blazak
+    make -f Makefile.lufa KEYMAP=dvorak
+    make -f Makefile.lufa KEYMAP=colemak
+    make -f Makefile.lufa KEYMAP=workman
+    make -f Makefile.lufa KEYMAP=micro
+    make -f Makefile.lufa KEYMAP=cub
 
 
 # Layouts
 
-TODO description of layouts in base firmware binaries
+## Filename
+
+The filename should be of the form `keymap_name.c'
+where `name' can be any text.
+Then, the build system should use your keymapfile when you use
+
+    make -f Makefile.lufa KEYMAP=name
+
+from above.
+
+## Writing
+
+First, it is best to get familar with one of the working examples above.
+If your lanugage is unsupported and you do not feel comfortable writing one, post an issue on github.
+keymap_name.c.template has no keymap defined and all the keymap templates in one place.
+If the keycodes are hard to figure out, /tmk_core/common/keycode.h has the whole list avalable.
+Please drop the `KC_' for each keycode when using keycodes from `keycode.h'.
 
 
 # Things TO-DO

--- a/keyboard/ergodox/keymap_name.c.template
+++ b/keyboard/ergodox/keymap_name.c.template
@@ -1,0 +1,100 @@
+#include <util/delay.h>
+#include "bootloader.h"
+#include "keymap_common.h"
+
+
+const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
+    /*
+     * Template for ascii-art versions of the keymap
+     *
+     * ,--------------------------------------------------.           ,--------------------------------------------------.
+     * |   ~    |   0  |   0  |   0  |   0  |   0  |   \  |           |   -  |   0  |   0  |   0  |   0  |   0  |   =    |
+     * |--------+------+------+------+------+-------------|           |------+------+------+------+------+------+--------|
+     * | Tab    |   a  |   a  |   a  |   a  |   a  |  L   |           |  L   |   a  |   a  |   a  |   a  |   a  |   [    |
+     * |--------+------+------+------+------+------|      |           |      |------+------+------+------+------+--------|
+     * | Tab/Shf|   a  |   a  |   a  |   a  |   a  |------|           |------|   a  |   a  |   a  |   a  |   a  |   '    |
+     * |--------+------+------+------+------+------|  L   |           |  L   |------+------+------+------+------+--------|
+     * | LCtrl  |   a  |   a  |   a  |   a  |   a  |      |           |      |   a  |   a  |   a  |   a  |   a  |   ]    |
+     * `--------+------+------+------+------+-------------'           `-------------+------+------+------+------+--------'
+     *   |  L   |  L   | Caps | LAlt | LGui |                                       |  Lft |  Up  |  Dn  | Rght |  L   |
+     *   `----------------------------------'                                       `----------------------------------'
+     *                                        ,-------------.       ,-------------.
+     *                                        |  L   | Home |       | PgUp | Del  |
+     *                                 ,------|------|------|       |------+------+------.
+     *                                 |      |      |  End |       | PgDn |      |      |
+     *                                 | BkSp |  ESC |------|       |------| Enter| Space|
+     *                                 |      |      |  Spc |       | Ins  |      |      |
+     *                                 `--------------------'       `--------------------'
+     *
+     */
+
+
+/*
+    // Template for keymap definition
+
+    KEYMAP(  // LayerN: transparent on edges + hard-defined thumb keys, all others are empty
+        // left hand
+        TRNS,NO,  NO,  NO,  NO,  NO,  NO,
+        TRNS,NO,  NO,  NO,  NO,  NO,  TRNS,
+        TRNS,NO,  NO,  NO,  NO,  NO,
+        TRNS,NO,  NO,  NO,  NO,  NO,  TRNS,
+        TRNS,TRNS,TRNS,LALT,LGUI,
+                                      TRNS,TRNS,
+                                           TRNS,
+                                 LCTL,LSFT,TRNS,
+        // right hand
+             NO,  NO,  NO,  NO,  NO,  NO,  TRNS,
+             TRNS,NO,  NO,  NO,  NO,  NO,  TRNS,
+                  NO,  NO,  NO,  NO,  NO,  TRNS,
+             TRNS,NO,  NO,  NO,  NO,  NO,  TRNS,
+                       RGUI,RALT,TRNS,TRNS,TRNS,
+        TRNS,TRNS,
+        TRNS,
+        TRNS,RSFT,RCTL
+    ),
+    KEYMAP(  // LayerN: fully transparent
+        // left hand
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+        TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+        TRNS,TRNS,TRNS,TRNS,TRNS,
+                                      TRNS,TRNS,
+                                           TRNS,
+                                 TRNS,TRNS,TRNS,
+        // right hand
+             TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+             TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+                  TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+             TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,TRNS,
+                       TRNS,TRNS,TRNS,TRNS,TRNS,
+        TRNS,TRNS,
+        TRNS,
+        TRNS,TRNS,TRNS
+    ),
+*/
+
+};
+
+/* id for user defined functions & macros */
+enum function_id {
+    TEENSY_KEY,
+};
+
+/*
+ * Fn action definition
+ */
+const uint16_t PROGMEM fn_actions[] = {
+    ACTION_FUNCTION(TEENSY_KEY),                    // FN0 - Teensy key
+};
+
+void action_function(keyrecord_t *event, uint8_t id, uint8_t opt)
+{
+    if (id == TEENSY_KEY) {
+        clear_keyboard();
+        print("\n\nJump to bootloader... ");
+        _delay_ms(250);
+        bootloader_jump(); // should not return
+        print("not supported.\n");
+    }
+}


### PR DESCRIPTION
The build section in the ErgoDox readme was incorrect.
the old layout name passing method no longer works because, a layout is not
a target.
The new way to specify Layout names is `KEYMAP=[desired keymap]'

Added a tiny primer on making new layouts.
Added a tiny template keymap to keep the verbosity down.